### PR TITLE
Fix xt002 heart, now cast the debuff Exposed Heart correctly

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_xt002.cpp
@@ -318,7 +318,7 @@ class boss_xt002 : public CreatureScript
                     DoMeleeAttackIfReady();
             }
 
-            void PassengerBoarded(Unit* who, int8 /*seatId*/, bool apply) override
+            void PassengerBoarded(Unit* who, int8 seatId, bool apply) override
             {
                 if (apply && who->GetEntry() == NPC_XS013_SCRAPBOT)
                 {
@@ -329,6 +329,10 @@ class boss_xt002 : public CreatureScript
                     Talk(EMOTE_SCRAPBOT);
                     _healthRecovered = true;
                 }
+//[AZTH]                
+                if (apply && who->GetEntry() == NPC_XT002_HEART && seatId == HEART_VEHICLE_SEAT_EXPOSED)
+                    who->CastSpell(who, SPELL_EXPOSED_HEART, false);    //Channeled
+//[/AZTH]
             }
 
             uint32 GetData(uint32 type) const override
@@ -374,7 +378,6 @@ class boss_xt002 : public CreatureScript
                     heart->CastSpell(heart, SPELL_HEART_OVERLOAD, false);
                     heart->CastSpell(me, SPELL_HEART_LIGHTNING_TETHER, false);
                     heart->CastSpell(heart, SPELL_HEART_HEAL_TO_FULL, true);
-                    heart->CastSpell(heart, SPELL_EXPOSED_HEART, false);    // Channeled
                     heart->ChangeSeat(HEART_VEHICLE_SEAT_EXPOSED, true);
                     heart->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                     heart->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNK_29);


### PR DESCRIPTION
**Changes proposed**:
Modified PassengerBoarded() function for avoid the delay issue when change seat on boss.

**Target branch(es)**: 335

**Issues addressed**: Fixes #

**Tests performed**: (Does it build? Tested in-game?)
Tested all three phases on my local and it seems to work

**Known issues and TODO list**:
